### PR TITLE
add helper library for erpc client/server

### DIFF
--- a/erpc/erpc.go
+++ b/erpc/erpc.go
@@ -1,0 +1,79 @@
+// Implements "exactly-once RPCs" with a reply table.
+package erpc
+
+import (
+	"github.com/tchajed/marshal"
+	"sync"
+)
+
+type Server struct {
+	mu        *sync.Mutex
+	lastSeq   map[uint64]uint64
+	lastReply map[uint64][]byte
+	lastCID   uint64
+}
+
+func (t *Server) HandleRequest(handler func(raw_args []byte, reply *[]byte)) func(raw_args []byte, reply *[]byte) {
+	return func(raw_args []byte, reply *[]byte) {
+		dec := marshal.NewDec(raw_args)
+		cid := dec.GetInt()
+		seq := dec.GetInt()
+
+		t.mu.Lock()
+		// check if we've seen this request before
+		last, ok := t.lastSeq[cid]
+		if ok && seq <= last {
+			// Old request repeated. This is either request `last`, and we send back that reply, or an
+			// even older one in which case we can send whatever since the client will already have
+			// moved on.
+			*reply = t.lastReply[cid]
+			t.mu.Unlock()
+			return
+		}
+
+		handler(dec.GetRemainingBytes(), reply)
+
+		t.lastSeq[cid] = seq
+		t.lastReply[cid] = *reply
+		t.mu.Unlock()
+	}
+}
+
+func (t *Server) GetFreshCID() uint64 {
+	t.mu.Lock()
+	t.lastCID += 1
+	ret := t.lastCID
+	t.mu.Unlock()
+	return ret
+}
+
+func MakeServer() *Server {
+	t := new(Server)
+	t.lastReply = make(map[uint64][]byte)
+	t.lastSeq = make(map[uint64]uint64)
+	t.lastCID = 0
+	t.mu = new(sync.Mutex)
+	return t
+}
+
+type Client struct {
+	cid uint64
+	seq uint64
+}
+
+func (c *Client) NewRequest(request []byte) []byte {
+	c.seq += 1
+
+	enc := marshal.NewEnc(2*8 + uint64(len(request)))
+	enc.PutInt(c.cid)
+	enc.PutInt(c.seq)
+	enc.PutBytes(request)
+	return enc.Finish()
+}
+
+func MakeClient(cid uint64) *Client {
+	c := new(Client)
+	c.cid = cid
+	c.seq = 0
+	return c
+}

--- a/fencing/ctr/0_marshal.go
+++ b/fencing/ctr/0_marshal.go
@@ -5,16 +5,12 @@ import (
 )
 
 type PutArgs struct {
-	cid   uint64
-	seq   uint64
 	epoch uint64
 	v     uint64
 }
 
 func EncPutArgs(args *PutArgs) []byte {
-	enc := marshal.NewEnc(uint64(24))
-	enc.PutInt(args.cid)
-	enc.PutInt(args.seq)
+	enc := marshal.NewEnc(uint64(8))
 	enc.PutInt(args.v)
 	enc.PutInt(args.epoch)
 	return enc.Finish()
@@ -23,23 +19,17 @@ func EncPutArgs(args *PutArgs) []byte {
 func DecPutArgs(raw_args []byte) *PutArgs {
 	dec := marshal.NewDec(raw_args)
 	args := new(PutArgs)
-	args.cid = dec.GetInt()
-	args.seq = dec.GetInt()
 	args.v = dec.GetInt()
 	args.epoch = dec.GetInt()
 	return args
 }
 
 type GetArgs struct {
-	cid   uint64
-	seq   uint64
 	epoch uint64
 }
 
 func EncGetArgs(args *GetArgs) []byte {
-	enc := marshal.NewEnc(uint64(24))
-	enc.PutInt(args.cid)
-	enc.PutInt(args.seq)
+	enc := marshal.NewEnc(uint64(8))
 	enc.PutInt(args.epoch)
 	return enc.Finish()
 }
@@ -47,8 +37,6 @@ func EncGetArgs(args *GetArgs) []byte {
 func DecGetArgs(raw_args []byte) *GetArgs {
 	dec := marshal.NewDec(raw_args)
 	args := new(GetArgs)
-	args.cid = dec.GetInt()
-	args.seq = dec.GetInt()
 	args.epoch = dec.GetInt()
 	return args
 }

--- a/fencing/ctr/client.go
+++ b/fencing/ctr/client.go
@@ -1,6 +1,7 @@
 package ctr
 
 import (
+	"github.com/mit-pdos/gokv/erpc"
 	"github.com/mit-pdos/gokv/grove_ffi"
 	"github.com/mit-pdos/gokv/urpc"
 	"github.com/tchajed/marshal"
@@ -14,22 +15,19 @@ const (
 )
 
 type Clerk struct {
-	cl  *urpc.Client
-	cid uint64
-	seq uint64
+	cl *urpc.Client
+	e  *erpc.Client
 }
 
 func (c *Clerk) Get(epoch uint64) uint64 {
-	// TODO: use prophecy to get rid of cid/seq
-	c.seq += 1
+	// TODO: use prophecy and don't use exactly-once RPC
 	args := &GetArgs{
 		epoch: epoch,
-		cid:   c.cid,
-		seq:   c.seq,
 	}
+	req := c.e.NewRequest(EncGetArgs(args))
 
 	reply_ptr := new([]byte)
-	err := c.cl.Call(RPC_GET, EncGetArgs(args), reply_ptr, 100 /* ms */)
+	err := c.cl.Call(RPC_GET, req, reply_ptr, 100 /* ms */)
 	if err != 0 {
 		log.Println("ctr: urpc get call failed/timed out")
 		grove_ffi.Exit(1)
@@ -44,16 +42,14 @@ func (c *Clerk) Get(epoch uint64) uint64 {
 }
 
 func (c *Clerk) Put(v uint64, epoch uint64) {
-	c.seq += 1
 	args := &PutArgs{
-		cid:   c.cid,
-		seq:   c.seq,
 		v:     v,
 		epoch: epoch,
 	}
+	req := c.e.NewRequest(EncPutArgs(args))
 
 	reply_ptr := new([]byte)
-	err := c.cl.Call(RPC_GET, EncPutArgs(args), reply_ptr, 100 /* ms */)
+	err := c.cl.Call(RPC_PUT, req, reply_ptr, 100 /* ms */)
 	if err != 0 {
 		log.Println("ctr: urpc put call failed/timed out")
 		grove_ffi.Exit(1)
@@ -71,16 +67,16 @@ func (c *Clerk) Put(v uint64, epoch uint64) {
 
 func MakeClerk(host grove_ffi.Address) *Clerk {
 	ck := new(Clerk)
-	ck.seq = 0
 	ck.cl = urpc.MakeClient(host)
 
 	reply_ptr := new([]byte)
-	err := ck.cl.Call(RPC_GET, make([]byte, 0), reply_ptr, 100 /* ms */)
+	err := ck.cl.Call(RPC_FRESHCID, make([]byte, 0), reply_ptr, 100 /* ms */)
 	if err != 0 {
 		panic("ctr: urpc call failed/timed out")
 		// log.Println("ctr: urpc getcid call failed/timed out")
 		// grove_ffi.Exit(1)
 	}
-	ck.cid = marshal.NewDec(*reply_ptr).GetInt()
+	ck.e = erpc.MakeClient(marshal.NewDec(*reply_ptr).GetInt())
+
 	return ck
 }

--- a/fencing/ctr/server.go
+++ b/fencing/ctr/server.go
@@ -1,6 +1,7 @@
 package ctr
 
 import (
+	"github.com/mit-pdos/gokv/erpc"
 	"github.com/mit-pdos/gokv/grove_ffi"
 	"github.com/mit-pdos/gokv/urpc"
 	"github.com/tchajed/marshal"
@@ -8,13 +9,11 @@ import (
 )
 
 type Server struct {
-	mu        *sync.Mutex
+	mu *sync.Mutex
+	e  *erpc.Server
+
 	v         uint64
 	lastEpoch uint64
-
-	lastSeq   map[uint64]uint64
-	lastReply map[uint64]uint64
-	lastCID   uint64
 }
 
 const (
@@ -29,18 +28,9 @@ func (s *Server) Put(args *PutArgs) uint64 {
 		s.mu.Unlock()
 		return EStale
 	}
+
 	s.lastEpoch = args.epoch
-
-	// check if we've seen this request before
-	last, ok := s.lastSeq[args.cid]
-	seq := args.seq
-	if ok && seq <= last {
-		s.mu.Unlock()
-		return ENone
-	}
-
 	s.v = args.v
-	s.lastSeq[args.cid] = seq
 
 	s.mu.Unlock()
 	return ENone
@@ -65,41 +55,31 @@ func (s *Server) Get(args *GetArgs, reply *GetReply) {
 	return
 }
 
-func (s *Server) GetFreshCID() uint64 {
-	s.mu.Lock()
-	s.lastCID += 1
-	ret := s.lastCID
-	s.mu.Unlock()
-	return ret
-}
-
 func StartServer(me grove_ffi.Address) {
 	s := new(Server)
 	s.mu = new(sync.Mutex)
-	s.lastCID = 0
+	s.e = erpc.MakeServer()
 	s.v = 0
-	s.lastSeq = make(map[uint64]uint64)
-	s.lastReply = make(map[uint64]uint64)
 
 	handlers := make(map[uint64]func([]byte, *[]byte))
-	handlers[RPC_GET] = func(raw_args []byte, raw_reply *[]byte) {
+	handlers[RPC_GET] = s.e.HandleRequest(func(raw_args []byte, raw_reply *[]byte) {
 		args := DecGetArgs(raw_args)
 		reply := new(GetReply)
 		s.Get(args, reply)
 		*raw_reply = EncGetReply(reply)
-	}
+	})
 
-	handlers[RPC_PUT] = func(raw_args []byte, reply *[]byte) {
+	handlers[RPC_PUT] = s.e.HandleRequest(func(raw_args []byte, reply *[]byte) {
 		args := DecPutArgs(raw_args)
 		err := s.Put(args)
 		enc := marshal.NewEnc(8)
 		enc.PutInt(err)
 		*reply = enc.Finish()
-	}
+	})
 
 	handlers[RPC_FRESHCID] = func(raw_args []byte, reply *[]byte) {
 		enc := marshal.NewEnc(8)
-		enc.PutInt(s.GetFreshCID())
+		enc.PutInt(s.e.GetFreshCID())
 		*reply = enc.Finish()
 	}
 


### PR DESCRIPTION
For now I only use it in the counter server, can do this for more servers if we agree this is the right API.

The thing I like least is that on the client side, we basically expose that the reply is unchanged -- we just provide a 'wrapper' to make the request into an eRPC request. But maybe that's okay? Alternatively we could have a method that calls `c.cl.Call` itself, and maybe even contains a (bounded?) retry loop.