### PR TITLE
Swap Marshal args order

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,8 @@
         src = pkgs.fetchFromGitHub {
           owner = "goose-lang";
           repo = "goose";
-          rev = "a4f2f84193d34f56dd84fc623adc43a6441da1eb";
-          sha256 = "1b1dfa1qsv2h7hy5x20zhic2npr5gz1zp76m1lab4v490adxj2rx";
+          rev = "67cf95ebfc80e80ddc40b0518e6d761cde44977c";
+          sha256 = "16040c4frxn9dk3xmajzg4jb7fi7q39hasfp94rpnphmpr4hvr51";
         };
         vendorHash = "sha256-HCJ8v3TSv4UrkOsRuENWVz5Z7zQ1UsOygx0Mo7MELzY=";
       };
@@ -27,10 +27,10 @@
         src = pkgs.fetchFromGitHub {
           owner = "mjschwenne";
           repo = "grackle";
-          rev = "101412356cdfbcad78f8aaa724101312928c4978";
-          sha256 = "06zf2bvrbbjhgrd6994h3wcaml7m83m6f9r61pj7y09xq9nw10br";
+          rev = "3a83c3b22f163da77d75bfdb3923f007af2ad515";
+          sha256 = "1bl8lx50qhl6yczjnwfwywx29nvinr20v2zjdc2zjqi8kcls7kqr";
         };
-        vendorHash = "sha256-Wk2v0HSAkrzxHJvCfbw6xOn0OQ1xukvYjDxk3c2LmH8=";
+        vendorHash = "sha256-c9+npmcdynfqSnxEZSdubVeN8Y3eYAwjya52vTJayY0=";
         checkPhase = false;
       };
     in

--- a/tutorial/kvservice/conditionalput_gk/conditionalput_gk.go
+++ b/tutorial/kvservice/conditionalput_gk/conditionalput_gk.go
@@ -16,7 +16,7 @@ type S struct {
 	NewVal      string
 }
 
-func Marshal(c S, prefix []byte) []byte {
+func Marshal(prefix []byte, c S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, c.OpId)

--- a/tutorial/kvservice/get_gk/get_gk.go
+++ b/tutorial/kvservice/get_gk/get_gk.go
@@ -14,7 +14,7 @@ type S struct {
 	Key  string
 }
 
-func Marshal(g S, prefix []byte) []byte {
+func Marshal(prefix []byte, g S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, g.OpId)

--- a/tutorial/kvservice/kvservice_rpc.gb.go
+++ b/tutorial/kvservice/kvservice_rpc.gb.go
@@ -32,7 +32,7 @@ func (cl *Client) getFreshNumRpc() (uint64, Error) {
 
 func (cl *Client) putRpc(args put_gk.S) Error {
 	var reply []byte
-	err := cl.cl.Call(rpcIdPut, put_gk.Marshal(args, make([]byte, 0)), &reply, 100)
+	err := cl.cl.Call(rpcIdPut, put_gk.Marshal(make([]byte, 0), args), &reply, 100)
 	if err == urpc.ErrNone {
 		return err
 	}
@@ -41,7 +41,7 @@ func (cl *Client) putRpc(args put_gk.S) Error {
 
 func (cl *Client) conditionalPutRpc(args conditionalput_gk.S) (string, Error) {
 	var reply []byte
-	err := cl.cl.Call(rpcIdConditionalPut, conditionalput_gk.Marshal(args, make([]byte, 0)), &reply, 100)
+	err := cl.cl.Call(rpcIdConditionalPut, conditionalput_gk.Marshal(make([]byte, 0), args), &reply, 100)
 	if err == urpc.ErrNone {
 		return string(reply), err
 	}
@@ -50,7 +50,7 @@ func (cl *Client) conditionalPutRpc(args conditionalput_gk.S) (string, Error) {
 
 func (cl *Client) getRpc(args get_gk.S) (string, Error) {
 	var reply []byte
-	err := cl.cl.Call(rpcIdGet, get_gk.Marshal(args, make([]byte, 0)), &reply, 100)
+	err := cl.cl.Call(rpcIdGet, get_gk.Marshal(make([]byte, 0), args), &reply, 100)
 	if err == urpc.ErrNone {
 		return string(reply), err
 	}

--- a/tutorial/kvservice/put_gk/put_gk.go
+++ b/tutorial/kvservice/put_gk/put_gk.go
@@ -15,7 +15,7 @@ type S struct {
 	Value string
 }
 
-func Marshal(p S, prefix []byte) []byte {
+func Marshal(prefix []byte, p S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, p.OpId)

--- a/tutorial/lockservice/1_lock_rpc.gb.go
+++ b/tutorial/lockservice/1_lock_rpc.gb.go
@@ -30,7 +30,7 @@ func (cl *Client) getFreshNum() (uint64, Error) {
 
 func (cl *Client) tryAcquire(id uint64) (uint64, Error) {
 	var reply []byte
-	args := lockrequest_gk.Marshal(lockrequest_gk.S{Id: id}, []byte{})
+	args := lockrequest_gk.Marshal([]byte{}, lockrequest_gk.S{Id: id})
 	err := cl.cl.Call(RPC_TRY_ACQUIRE, args, &reply, 100)
 	if err == urpc.ErrNone {
 		return DecodeUint64(reply), err
@@ -40,7 +40,7 @@ func (cl *Client) tryAcquire(id uint64) (uint64, Error) {
 
 func (cl *Client) release(id uint64) Error {
 	var reply []byte
-	args := lockrequest_gk.Marshal(lockrequest_gk.S{Id: id}, []byte{})
+	args := lockrequest_gk.Marshal([]byte{}, lockrequest_gk.S{Id: id})
 	return cl.cl.Call(RPC_RELEASE, args, &reply, 100)
 }
 

--- a/tutorial/lockservice/lockrequest_gk/lockrequest_gk.go
+++ b/tutorial/lockservice/lockrequest_gk/lockrequest_gk.go
@@ -13,7 +13,7 @@ type S struct {
 	Id uint64
 }
 
-func Marshal(l S, prefix []byte) []byte {
+func Marshal(prefix []byte, l S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, l.Id)

--- a/tutorial/objectstore/chunk/client.go
+++ b/tutorial/objectstore/chunk/client.go
@@ -20,7 +20,7 @@ type ClerkPool struct {
 }
 
 func (ck *ClerkPool) WriteChunk(addr grove_ffi.Address, args writechunk_gk.S) {
-	req := writechunk_gk.Marshal(args, make([]byte, 0))
+	req := writechunk_gk.Marshal(make([]byte, 0), args)
 	reply := new([]byte)
 	ck.cm.CallAtLeastOnce(addr, WriteChunkId, req, reply, 100 /*ms*/)
 }

--- a/tutorial/objectstore/chunk/writechunk_gk/writechunk_gk.go
+++ b/tutorial/objectstore/chunk/writechunk_gk/writechunk_gk.go
@@ -15,7 +15,7 @@ type S struct {
 	Index   uint64
 }
 
-func Marshal(w S, prefix []byte) []byte {
+func Marshal(prefix []byte, w S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, w.WriteId)

--- a/tutorial/objectstore/dir/chunkhandle_gk/chunkhandle_gk.go
+++ b/tutorial/objectstore/dir/chunkhandle_gk/chunkhandle_gk.go
@@ -14,7 +14,7 @@ type S struct {
 	ContentHash string
 }
 
-func Marshal(c S, prefix []byte) []byte {
+func Marshal(prefix []byte, c S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, c.Addr)

--- a/tutorial/objectstore/dir/client.go
+++ b/tutorial/objectstore/dir/client.go
@@ -36,14 +36,14 @@ func (ck *Clerk) PrepareWrite() PreparedWrite {
 
 // From chunk
 func (ck *Clerk) RecordChunk(args recordchunk_gk.S) {
-	req := recordchunk_gk.Marshal(args, make([]byte, 0))
+	req := recordchunk_gk.Marshal(make([]byte, 0), args)
 	reply := new([]byte)
 	ck.client.Call(RecordChunkId, req, reply, 100 /*ms*/)
 }
 
 // From chunk
 func (ck *Clerk) FinishWrite(args finishwrite_gk.S) {
-	req := finishwrite_gk.Marshal(args, make([]byte, 0))
+	req := finishwrite_gk.Marshal(make([]byte, 0), args)
 	reply := new([]byte)
 	ck.client.Call(FinishWriteId, req, reply, 100 /*ms*/)
 }

--- a/tutorial/objectstore/dir/finishwrite_gk/finishwrite_gk.go
+++ b/tutorial/objectstore/dir/finishwrite_gk/finishwrite_gk.go
@@ -14,7 +14,7 @@ type S struct {
 	Keyname string
 }
 
-func Marshal(f S, prefix []byte) []byte {
+func Marshal(prefix []byte, f S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, f.WriteId)

--- a/tutorial/objectstore/dir/recordchunk_gk/recordchunk_gk.go
+++ b/tutorial/objectstore/dir/recordchunk_gk/recordchunk_gk.go
@@ -16,7 +16,7 @@ type S struct {
 	Index       uint64
 }
 
-func Marshal(r S, prefix []byte) []byte {
+func Marshal(prefix []byte, r S) []byte {
 	var enc = prefix
 
 	enc = marshal.WriteInt(enc, r.WriteId)


### PR DESCRIPTION
As a result of [PR#5 for the marshaling library](https://github.com/tchajed/marshal/pull/5), I had to swap the order of arguments for the `Marshal` functions. This PR fixes that. 